### PR TITLE
tests: fix handling of tmp dir

### DIFF
--- a/tests/package_to_single_test.py
+++ b/tests/package_to_single_test.py
@@ -25,12 +25,15 @@ class PackageToSingleText(unittest.TestCase):
 
     def test_with_output_dir(self):
         out_dir = get_tmp_path()
+        out_dir.mkdir(exist_ok=True)
         package_to_single(get_mono_path(), out_dir)
         out_file = out_dir / "JetBrainsMono-Italic.glyphs"
         assert out_file.is_file()
 
     def test_with_output_file(self):
-        out_file = get_tmp_path() / "custom.glyphs"
+        out_dir = get_tmp_path()
+        out_dir.mkdir(exist_ok=True)
+        out_file = out_dir / "custom.glyphs"
         package_to_single(get_mono_path(), out_file)
         assert out_file.is_file()
 
@@ -41,3 +44,4 @@ class PackageToSingleText(unittest.TestCase):
                 entry.rmdir()
             else:
                 entry.unlink()
+        get_tmp_path().rmdir()


### PR DESCRIPTION
If the tests are run in a fresh git checkout where the `tests/data/tmp` directory doesn't exist, the `test_with_output_dir()` case would create it as a *file* instead of a directory, and then the `test_with_output_file()` case would subsequently fail.

Ensure the tmp directory is actually a directory in each case.

Also ensure the tmp directory itself is removed at the end of the tests, which reveals this issue.